### PR TITLE
Evabyte setup

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,35 @@
+{
+    // Name of the dev container
+    "name": "CSE517P Project Dev Container",
+    // Dockerfile to build the container
+    "build": {
+        "dockerfile": "../Dockerfile"
+    },
+    // Features to include in the dev container
+    "features": {},
+    // Customizations for the VS Code environment
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "ms-python.python",
+                "ms-python.vscode-pylance",
+                "ms-toolsai.jupyter"
+            ]
+        }
+    },
+    // Forward ports from the container to the host
+    "forwardPorts": [
+        8080,
+        8888
+    ],
+    // Mount local folders into the container
+    "mounts": [
+        "source=${localWorkspaceFolder},target=/workspace,type=bind,consistency=cached"
+    ],
+    // Set the default workspace folder
+    "workspaceFolder": "/workspace",
+    // Specify container environment variables
+    "remoteEnv": {
+        "PYTHONPATH": "/workspace"
+    }
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,7 +3,8 @@
     "name": "CSE517P Project Dev Container",
     // Dockerfile to build the container
     "build": {
-        "dockerfile": "../Dockerfile"
+        "dockerfile": "../Dockerfile",
+        "target": "dev"
     },
     // Features to include in the dev container
     "features": {},

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ work/
 output/
 submit/
 submit.zip
+data/

--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -4,13 +4,13 @@ Instructions for development.
 
 ## Development
 
-`docker build --target runtime -t evabyte:runtime .` to build runtime image.
+Either open project root directory in VSCode and load devcontainer, or build via `make`:
 
-`docker build --target dev -t evabyte:dev .` to build dev image.
-
-`docker run -ti --gpus all -v"$(pwd)/src:/job/src" --entrypoint bash evabyte:dev` to bash into dev image and mount local src directory into image (in read/write mode -- writes inside container are persisted to host).
-
-Or, open project root directory in VSCode and load devcontainer.
+- `make build-runtime` to build the minimal runtime image `evabyte:runtime`
+- `make build-dev` to build the development image
+- `run-runtime` to run an interactive shell in the minimal runtime image
+- `run-dev` to run an interactive shell in the development image
+- `shell-dev` to open an additional shell in the development image
 
 ## Notes
 

--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -1,0 +1,16 @@
+# Overview
+
+Instructions for development.
+
+## Development
+
+`docker build -t evabyte .` to build image.
+
+`docker run -ti --gpus all -v"$(pwd)/src:/job/src" --entrypoint bash evabyte` to bash into image and mount local src directory into image (in read/write mode -- writes inside container are persisted to host).
+
+## Notes
+
+Various notes and thoughts that occurred that we may want to keep in mind.
+
+1. According to Ed in [this discussion](https://edstem.org/us/courses/77432/discussion/6630668), timing starts when "docker build -t" _starts_, rather than when it ends. This means optimizing build time and keeping on the same base image will be helpful for speed.
+2. I've asked [here](https://edstem.org/us/courses/77432/discussion/6658204) what machine we'll be running on. GPU type will be especially important.

--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -4,9 +4,13 @@ Instructions for development.
 
 ## Development
 
-`docker build -t evabyte .` to build image.
+`docker build --target runtime -t evabyte:runtime .` to build runtime image.
 
-`docker run -ti --gpus all -v"$(pwd)/src:/job/src" --entrypoint bash evabyte` to bash into image and mount local src directory into image (in read/write mode -- writes inside container are persisted to host).
+`docker build --target dev -t evabyte:dev .` to build dev image.
+
+`docker run -ti --gpus all -v"$(pwd)/src:/job/src" --entrypoint bash evabyte:dev` to bash into dev image and mount local src directory into image (in read/write mode -- writes inside container are persisted to host).
+
+Or, open project root directory in VSCode and load devcontainer.
 
 ## Notes
 

--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -12,5 +12,6 @@ Instructions for development.
 
 Various notes and thoughts that occurred that we may want to keep in mind.
 
-1. According to Ed in [this discussion](https://edstem.org/us/courses/77432/discussion/6630668), timing starts when "docker build -t" _starts_, rather than when it ends. This means optimizing build time and keeping on the same base image will be helpful for speed.
-2. I've asked [here](https://edstem.org/us/courses/77432/discussion/6658204) what machine we'll be running on. GPU type will be especially important.
+1. According to Ed in [this discussion](https://edstem.org/us/courses/77432/discussion/6630668), timing starts when "docker build -t" _starts_, rather than when it ends. This means optimizing build time and keeping on the same base image will be helpful for speed. We should try to find the right balance between setup time (docker build time, model download and load time) and inference time.
+2. The base image for the inference runtime doesn't have gcc or clang, which are required by triton.
+3. I've asked [here](https://edstem.org/us/courses/77432/discussion/6658204) what machine we'll be running on. GPU type will be especially important.

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ RUN mkdir /job
 WORKDIR /job
 VOLUME ["/job/data", "/job/src", "/job/work", "/job/output"]
 
-RUN apt update && apt install -y build-essential vim
+RUN apt update && apt install -y build-essential # triton needs gcc
 
 COPY requirements.txt /job/requirements.txt
 RUN pip install -r /job/requirements.txt
@@ -19,7 +19,10 @@ RUN apt-get update && apt-get install -y \
     build-essential \
     git \
     curl \
+    less \
+    htop \
     vim
+
 
 COPY requirements_dev.txt /job/requirements_dev.txt
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,8 @@ RUN mkdir /job
 WORKDIR /job
 VOLUME ["/job/data", "/job/src", "/job/work", "/job/output"]
 
+RUN apt update && apt install -y build-essential vim
+
 RUN pip install transformers triton
 
 COPY src /job/src

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,26 @@
-FROM pytorch/pytorch:2.6.0-cuda12.4-cudnn9-runtime
+# slim inference runtime image -- should be built fast
+FROM pytorch/pytorch:2.6.0-cuda12.4-cudnn9-runtime AS runtime
 RUN mkdir /job
 WORKDIR /job
 VOLUME ["/job/data", "/job/src", "/job/work", "/job/output"]
 
 RUN apt update && apt install -y build-essential vim
 
-RUN pip install transformers triton
+COPY requirements.txt /job/requirements.txt
+RUN pip install -r /job/requirements.txt
 
 COPY src /job/src
 
-# You should install any dependencies you need here.
-# RUN pip install tqdm
+# development image -- this is the one devcontainer.json uses.
+# we can put a kitchen sink here.
+FROM runtime AS dev
+
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    git \
+    curl \
+    vim
+
+COPY requirements_dev.txt /job/requirements_dev.txt
+
+RUN pip install -r /job/requirements_dev.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,5 +3,9 @@ RUN mkdir /job
 WORKDIR /job
 VOLUME ["/job/data", "/job/src", "/job/work", "/job/output"]
 
+RUN pip install transformers triton
+
+COPY src /job/src
+
 # You should install any dependencies you need here.
 # RUN pip install tqdm

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,40 @@
+# Image tags
+RUNTIME_TAG=evabyte:runtime
+DEV_TAG=evabyte:dev
+
+# Dockerfile location
+DOCKERFILE=Dockerfile
+
+.PHONY: all build-runtime build-dev run-runtime run-dev shell-dev
+
+all: build-runtime build-dev
+
+build-runtime:
+	docker build --target runtime -t $(RUNTIME_TAG) -f $(DOCKERFILE) .
+
+build-dev:
+	docker build --target dev -t $(DEV_TAG) -f $(DOCKERFILE) .
+
+run-runtime:
+	docker run --rm -it \
+		-v $(PWD)/src:/job/src \
+		-v $(PWD)/data:/job/data \
+		-v $(PWD)/work:/job/work \
+		-v $(PWD)/output:/job/output \
+		--gpus all \
+		$(RUNTIME_TAG)
+
+run-dev:
+	docker run --rm -it \
+		-v $(PWD)/src:/job/src \
+		-v $(PWD)/data:/job/data \
+		-v $(PWD)/work:/job/work \
+		-v $(PWD)/output:/job/output \
+		-v $(PWD):/workspace \
+		--gpus all \
+		--name devcontainer \
+		$(DEV_TAG)
+
+shell-dev:
+	docker exec -it devcontainer /bin/bash
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+transformers==4.51.3
+triton==3.2.0

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,0 +1,2 @@
+ipython
+jupyterlab

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,2 +1,1 @@
 ipython
-jupyterlab

--- a/src/evabyte_example.py
+++ b/src/evabyte_example.py
@@ -1,0 +1,39 @@
+from transformers import AutoTokenizer, AutoModelForCausalLM
+import torch
+
+# BLAH
+
+# Load model and tokenizer
+tokenizer = AutoTokenizer.from_pretrained("evabyte/EvaByte", trust_remote_code=True)
+model = AutoModelForCausalLM.from_pretrained("evabyte/EvaByte", torch_dtype=torch.bfloat16, trust_remote_code=True).eval().to("cuda")
+
+prompt = "The quick brown fox jumps "
+
+# Tokenize input
+# Option 1: standard HF tokenizer interface
+input_ids = tokenizer(prompt, return_tensors="pt").input_ids.to("cuda")
+
+# Option 2: Direct UTF-8 byte encoding with offset
+# Note: Each byte is offset by 64 with <bos> prepended.
+input_ids = torch.tensor([[1] + [b + 64 for b in prompt.encode("utf-8")]]).to("cuda")
+
+# byte-by-byte generation (default)
+generation_output = model.generate(
+    input_ids=input_ids, 
+    max_new_tokens=32
+)
+# alternatively, use faster multibyte generation
+generation_output = model.multi_byte_generate(
+    input_ids=input_ids, 
+    max_new_tokens=32
+)
+
+# Decode and print the output
+response = tokenizer.decode(
+    generation_output[0][input_ids.shape[1]:], 
+    skip_special_tokens=False,
+    clean_up_tokenization_spaces=False
+)
+print(response)
+# Sample output:
+# over the lazy dog.\n\nThe quick


### PR DESCRIPTION
Setting up the repository to be able to run an example evabyte script:

* Modifies Dockerfile with runtime and dev image targets, with makefile targets to build/run images.
* Adds a `devcontainer.json` for VS code development
* Adds the [evabyte](https://github.com/OpenEvaByte/evabyte) test script.
* Adds a `DEVELOPMENT.md` with instructions.

Verified that `/job/src/evabyte_example.py` can run on an L4 (`g2-standard-4` in GCP) -- unsure what GPU we'd be able to use, but I asked on ed.